### PR TITLE
Update english locale for attributes in item list sortby

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -292,12 +292,12 @@
       "rarity": "Rarity",
       "rarity_desc": "Rarity",
       "luck": "Luck",
-      "dex": "Dex",
+      "dex": "Dexterity",
       "cute": "Cute",
-      "def": "Def",
-      "str": "Str",
-      "int": "Int",
-      "con": "Con"
+      "def": "Defense",
+      "str": "Strength",
+      "int": "Intelligence",
+      "con": "Constitution"
     },
     "sort_order": "Order",
     "sort_order_options": {


### PR DESCRIPTION
Not sure if this will make the attributes too large, can consider replacing them with the all caps for the english case specifically.