### PR TITLE
add UniV3 Hedged Matic/usdc

### DIFF
--- a/otter-graphql-schema.json
+++ b/otter-graphql-schema.json
@@ -8260,6 +8260,22 @@
             "deprecationReason": null
           },
           {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigDecimal",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalBurnedClam",
             "description": null,
             "args": [],
@@ -12577,6 +12593,118 @@
             "deprecationReason": null
           },
           {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalBurnedClam",
             "description": null,
             "type": {
@@ -13162,6 +13290,12 @@
           },
           {
             "name": "treasuryUniV3UsdcMaiStrategyMarketValue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "treasuryUniV3HedgedMaticUsdcStrategyMarketValue",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -22295,6 +22429,38 @@
             "deprecationReason": null
           },
           {
+            "name": "maticClamAmount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigDecimal",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "BigDecimal",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalRevenueClamAmount",
             "description": null,
             "args": [],
@@ -25028,6 +25194,230 @@
             "deprecationReason": null
           },
           {
+            "name": "maticClamAmount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "BigDecimal",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigDecimal",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "totalRevenueClamAmount",
             "description": null,
             "type": {
@@ -25417,6 +25807,18 @@
           },
           {
             "name": "maiMarketValue",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticClamAmount",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "maticMarketValue",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/components/TreasuryMarketValueChart.tsx
+++ b/src/components/TreasuryMarketValueChart.tsx
@@ -118,6 +118,11 @@ const marketValues = [
     stopColor: ['rgba(131, 71, 229, 0.8)', 'rgba(131, 71, 229, 0.5)'],
   },
   {
+    label: 'Hedged MATIC/USDC (UniV3)',
+    dataKey: 'treasuryUniV3HedgedMaticUsdcStrategyMarketValue',
+    stopColor: ['rgba(131, 71, 229, 0.8)', 'rgba(131, 71, 229, 0.5)'],
+  },
+  {
     label: 'Qi',
     dataKey: 'treasuryQiMarketValue',
     stopColor: ['#F4D258', 'rgba(244, 210, 88, 0.5)'],

--- a/src/components/TreasuryRevenuesChart.tsx
+++ b/src/components/TreasuryRevenuesChart.tsx
@@ -23,10 +23,11 @@ const yAxisTickProps = { fontSize: '12px' }
 
 const dataKeysSettings = {
   [Currency.CLAM]: [
-    { dataKey: 'qiClamAmount', colors: ['rgba(244, 210, 88, 1)', 'rgba(244, 210, 88, 0.5)'], label: 'Qi' },
     { dataKey: 'ottopiaClamAmount', colors: ['rgba(255, 172, 161, 1)', 'rgba(255, 172, 161, 0.5)'], label: 'CLAM' },
+    { dataKey: 'qiClamAmount', colors: ['rgba(244, 210, 88, 1)', 'rgba(244, 210, 88, 0.5)'], label: 'Qi' },
     { dataKey: 'ldoClamAmount', colors: ['rgba(83, 211, 224, 1)', 'rgba(83, 200, 200, 0.5)'], label: 'Lido' },
     { dataKey: 'kncClamAmount', colors: ['rgba(49, 203, 158, 1)', 'rgba(49, 203, 158, 0.5)'], label: 'KNC' },
+    { dataKey: 'maticClamAmount', colors: ['rgba(131, 71, 229, 1)', 'rgba(131, 71, 229, 0.5)'], label: 'MATIC' },
     { dataKey: 'dystClamAmount', colors: ['rgba(8, 95, 142, 1)', 'rgba(8, 95, 142, 0.5)'], label: 'DYST' },
     { dataKey: 'penDystClamAmount', colors: ['rgba(108, 111, 227, 1)', 'rgba(8, 95, 142, 0.5)'], label: 'penDYST' },
     { dataKey: 'penClamAmount', colors: ['rgba(128, 131, 235, 1)', 'rgba(252, 236, 255, 0.5)'], label: 'PEN' },
@@ -36,10 +37,11 @@ const dataKeysSettings = {
     { dataKey: 'maiClamAmount', colors: ['rgba(219, 55, 55, 1)', 'rgba(219, 55, 55, 0.5)'], label: 'MAI' },
   ],
   [Currency.USD]: [
-    { dataKey: 'qiMarketValue', colors: ['rgba(244, 210, 88, 1)', 'rgba(244, 210, 88, 0.5)'], label: 'Qi' },
     { dataKey: 'ottopiaMarketValue', colors: ['rgba(255, 172, 161, 1)', 'rgba(255, 172, 161, 0.5)'], label: 'CLAM' },
+    { dataKey: 'qiMarketValue', colors: ['rgba(244, 210, 88, 1)', 'rgba(244, 210, 88, 0.5)'], label: 'Qi' },
     { dataKey: 'ldoMarketValue', colors: ['rgba(83, 200, 220, 1)', 'rgba(83, 211, 224, 0.5)'], label: 'Lido' },
     { dataKey: 'kncMarketValue', colors: ['rgba(49, 203, 158, 1)', 'rgba(49, 203, 158, 0.5)'], label: 'KNC' },
+    { dataKey: 'maticMarketValue', colors: ['rgba(131, 71, 229, 1)', 'rgba(131, 71, 229, 0.5)'], label: 'MATIC' },
     { dataKey: 'dystMarketValue', colors: ['rgba(8, 95, 142, 1)', 'rgba(8, 95, 142, 0.5)'], label: 'DYST' },
     { dataKey: 'penDystMarketValue', colors: ['rgba(108, 111, 227, 1)', 'rgba(8, 95, 142, 0.5)'], label: 'penDYST' },
     { dataKey: 'penMarketValue', colors: ['rgba(128, 131, 235, 1)', 'rgba(252, 236, 255, 0.5)'], label: 'PEN' },

--- a/src/graphs/__generated__/GetTreasuryMetrics.ts
+++ b/src/graphs/__generated__/GetTreasuryMetrics.ts
@@ -47,6 +47,7 @@ export interface GetTreasuryMetrics_protocolMetrics {
   treasuryDystopiaPairUsdplusStMaticMarketValue: any;
   treasuryPenroseHedgedMaticMarketValue: any;
   treasuryKyberswapMaticStMaticHedgedMarketValue: any;
+  treasuryUniV3HedgedMaticUsdcStrategyMarketValue: any;
   treasuryUniV3UsdcMaiStrategyMarketValue: any;
 }
 

--- a/src/graphs/__generated__/GetTreasuryRevenue.ts
+++ b/src/graphs/__generated__/GetTreasuryRevenue.ts
@@ -33,6 +33,8 @@ export interface GetTreasuryRevenue_treasuryRevenues {
   maiMarketValue: any;
   usdcClamAmount: any;
   usdcMarketValue: any;
+  maticClamAmount: any;
+  maticMarketValue: any;
   totalRevenueClamAmount: any;
   totalRevenueMarketValue: any;
 }

--- a/src/graphs/otter.ts
+++ b/src/graphs/otter.ts
@@ -67,6 +67,7 @@ export const GET_TREASURY_METRICS = gql`
       treasuryDystopiaPairUsdplusStMaticMarketValue
       treasuryPenroseHedgedMaticMarketValue
       treasuryKyberswapMaticStMaticHedgedMarketValue
+      treasuryUniV3HedgedMaticUsdcStrategyMarketValue
       treasuryUniV3UsdcMaiStrategyMarketValue
     }
   }
@@ -99,6 +100,8 @@ export const GET_TREASURY_REVENUE = gql`
       maiMarketValue
       usdcClamAmount
       usdcMarketValue
+      maticClamAmount
+      maticMarketValue
       totalRevenueClamAmount
       totalRevenueMarketValue
     }


### PR DESCRIPTION
Also rearranged the revenue so CLAM is the first tooltip item

MATIC revenue will show up when revenue is over $0.50, i.e. `Math.round(x) > 0`