### PR TITLE
fix: conditional Boost should display the next closest condition, not…

### DIFF
--- a/src/models/AdventureDisplayedBoost.tsx
+++ b/src/models/AdventureDisplayedBoost.tsx
@@ -230,7 +230,9 @@ const parseFirstMatchGroup = (
 
   return {
     boostType: BoostType.FirstMatchGroup,
-    message: details ? group.map(stringifyBoost).join('<br />') : stringifyBoost(effectiveBoost ?? firstMatchedBoost),
+    message: details
+      ? group.map(stringifyBoost).join('<br />')
+      : stringifyBoost(effectiveBoost ?? group[group.length - 1]),
     effective: Boolean(effectiveBoost),
     attr: condition.attr,
     boosts: group,


### PR DESCRIPTION
… the highest