### PR TITLE
Fix react hydration failure message

### DIFF
--- a/src/components/ImageButton.tsx
+++ b/src/components/ImageButton.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, PropsWithChildren } from 'react'
+import { ComponentProps, PropsWithChildren, forwardRef } from 'react'
 import styled from 'styled-components/macro'
 
 interface NextImage {
@@ -34,7 +34,7 @@ export type ImageButtonProps = ComponentProps<typeof StyledButton> & {
   scale?: number
 }
 
-export default React.forwardRef(function ImageButton(
+export default forwardRef(function ImageButton(
   { scale = 0.5, states = [], ...restProps }: PropsWithChildren<ImageButtonProps>,
   ref
 ) {

--- a/src/components/ImageButton.tsx
+++ b/src/components/ImageButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, PropsWithChildren } from 'react'
+import React, { ComponentProps, PropsWithChildren } from 'react'
 import styled from 'styled-components/macro'
 
 interface NextImage {
@@ -34,6 +34,9 @@ export type ImageButtonProps = ComponentProps<typeof StyledButton> & {
   scale?: number
 }
 
-export default function ImageButton({ scale = 0.5, states = [], ...restProps }: PropsWithChildren<ImageButtonProps>) {
+export default React.forwardRef(function ImageButton(
+  { scale = 0.5, states = [], ...restProps }: PropsWithChildren<ImageButtonProps>,
+  ref
+) {
   return <StyledButton scale={scale} states={states} {...restProps} />
-}
+})

--- a/src/components/PageHeader/FishWalletPopup/index.tsx
+++ b/src/components/PageHeader/FishWalletPopup/index.tsx
@@ -1,5 +1,5 @@
 import BorderContainer from 'components/BorderContainer'
-import { RefObject, useEffect } from 'react'
+import { RefObject, useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { hideFishWalletPopup, selectShowFishWalletPopup } from 'store/uiSlice'
@@ -57,8 +57,10 @@ export default function FishWalletPopup({ alignRef, className }: Props) {
   const show = useSelector(selectShowFishWalletPopup)
   const dispatch = useDispatch()
   const onClose = () => dispatch(hideFishWalletPopup())
+  const [hydrated, setHydrated] = useState(false)
 
   useEffect(() => {
+    setHydrated(true)
     if (show) {
       document.body.style.overflow = 'hidden'
       return () => {
@@ -69,7 +71,7 @@ export default function FishWalletPopup({ alignRef, className }: Props) {
 
   const { left, bottom } = alignRef?.current?.getBoundingClientRect() || { left: 0, bottom: 0 }
 
-  if (show) {
+  if (hydrated) {
     const dom = (
       <StyledPopup show={show}>
         <StyledBackground onClick={onClose} />

--- a/src/components/PageHeader/FishWalletPopup/index.tsx
+++ b/src/components/PageHeader/FishWalletPopup/index.tsx
@@ -67,20 +67,20 @@ export default function FishWalletPopup({ alignRef, className }: Props) {
     }
   }, [show])
 
-  if (typeof document === 'undefined') return null
-
   const { left, bottom } = alignRef?.current?.getBoundingClientRect() || { left: 0, bottom: 0 }
 
-  const dom = (
-    <StyledPopup show={show}>
-      <StyledBackground onClick={onClose} />
-      <StyledWalletPopup className={className} top={bottom} left={left}>
-        <StyledBorderContainer size="xs">
-          <StyledSwap onClose={onClose} />
-        </StyledBorderContainer>
-      </StyledWalletPopup>
-    </StyledPopup>
-  )
-
-  return ReactDOM.createPortal(dom, document.querySelector('#modal-root') ?? document.body)
+  if (show) {
+    const dom = (
+      <StyledPopup show={show}>
+        <StyledBackground onClick={onClose} />
+        <StyledWalletPopup className={className} top={bottom} left={left}>
+          <StyledBorderContainer size="xs">
+            <StyledSwap onClose={onClose} />
+          </StyledBorderContainer>
+        </StyledWalletPopup>
+      </StyledPopup>
+    )
+    return ReactDOM.createPortal(dom, document.querySelector('#modal-root') ?? document.body)
+  }
+  return null
 }


### PR DESCRIPTION
Fixes popup in dev where hydration 'fails' due to mismatch between server and client.
Fixes a warning about forwarding refs, caused by https://github.com/vercel/next.js/issues/7915

There are still react hydration errors, but following https://nextjs.org/docs/messages/react-hydration-error in using babel styled components does not address the problem from what I tried.