### PR TITLE
Fix: Final change to Explore Now button

### DIFF
--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -174,16 +174,14 @@ export default function ResultStep() {
     return null
   }
 
-  const exploreAgainButton = (
+  const exploreAgainButton = otto?.adventureStatus !== AdventureOttoStatus.Resting && (
     <Button
       Typography={Headline}
       onClick={() => {
         closePopup();
         openPopup(
           undefined,
-          otto?.adventureStatus === AdventureOttoStatus.Resting
-            ? AdventurePopupStep.Resting
-            : AdventurePopupStep.Map
+          AdventurePopupStep.Map
         );
       }}
     >

--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -174,8 +174,25 @@ export default function ResultStep() {
     return null
   }
 
+  const exploreAgainButton = (
+    <Button
+      Typography={Headline}
+      onClick={() => {
+        closePopup();
+        openPopup(
+          undefined,
+          otto?.adventureStatus === AdventureOttoStatus.Resting
+            ? AdventurePopupStep.Resting
+            : AdventurePopupStep.Map
+        );
+      }}
+    >
+      {t('explore_again_btn')}
+    </Button>
+  );
+
   return (
-    <StyledResultStep bg={location.bgImageBlack}>
+    <StyledResultStep bg={location?.bgImageBlack}>
       {result && displayedOtto && (
         <Head>
           <title>
@@ -215,34 +232,22 @@ export default function ResultStep() {
         {result && displayedOtto && <StyledRewardSection result={result} otto={displayedOtto} />}
         {result && (
           <StyledButtons>
-            {otto && result.success && (
-              <Button
-                Typography={Headline}
-                onClick={() => {
-                  closePopup()
-                  openPopup(
-                    undefined,
-                    otto?.adventureStatus === AdventureOttoStatus.Resting
-                      ? AdventurePopupStep.Resting
-                      : AdventurePopupStep.Map
-                  )
-                }}
-              >
-                {t('explore_again_btn')}
-              </Button>
+            {otto && !result.success && !result.revived && (
+              <>
+                <PaymentButton
+                  Typography={Headline}
+                  loading={reviveState.status === 'PendingSignature' || reviveState.status === 'Mining'}
+                  spenderAddress={ADVENTURE}
+                  token={MATIC}
+                  amount={price || '0'}
+                  onClick={() => otto && revive(otto.id, { value: price || '0', gasLimit: 2000000 })}
+                >
+                  {t('revive_btn')}
+                </PaymentButton>
+                {exploreAgainButton}
+              </>
             )}
-            {otto && !(result.success || result.revived) && (
-              <PaymentButton
-                Typography={Headline}
-                loading={reviveState.status === 'PendingSignature' || reviveState.status === 'Mining'}
-                spenderAddress={ADVENTURE}
-                token={MATIC}
-                amount={price || '0'}
-                onClick={() => otto && revive(otto.id, { value: price || '0', gasLimit: 2000000 })}
-              >
-                {t('revive_btn')}
-              </PaymentButton>
-            )}
+            {otto && (result.success || result.revived) && exploreAgainButton}
             <StyledButtonGroup>
               <Button width="50%" Typography={Headline} primaryColor="white" onClick={share}>
                 <StyledShareButtonText>{t('share_btn')}</StyledShareButtonText>

--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -174,18 +174,18 @@ export default function ResultStep() {
     return null
   }
 
-  const exploreAgainButton = otto?.adventureStatus !== AdventureOttoStatus.Resting && (
-  <Button
-    Typography={Headline}
-    onClick={() => {
-      setOtto(otto, true);
-      closePopup();
-      openPopup(undefined, AdventurePopupStep.Map);
-    }}
-  >
-    {t('explore_again_btn')}
-  </Button>
-);
+  const exploreAgainButton = otto?.adventureStatus === AdventureOttoStatus.Ready && (
+    <Button
+      Typography={Headline}
+      onClick={() => {
+        setOtto(otto, true);
+        closePopup();
+        openPopup(undefined, AdventurePopupStep.Map);
+      }}
+    >
+      {t('explore_again_btn')}
+    </Button>
+  );
 
   return (
     <StyledResultStep bg={location.bgImageBlack}>

--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -180,7 +180,7 @@ export default function ResultStep() {
       onClick={() => {
         setOtto(otto, true);
         closePopup();
-        openPopup(undefined, AdventurePopupStep.Map);
+        openPopup(location.id, AdventurePopupStep.PreviewOtto);
       }}
     >
       {t('explore_again_btn')}

--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -192,7 +192,7 @@ export default function ResultStep() {
   );
 
   return (
-    <StyledResultStep bg={location?.bgImageBlack}>
+    <StyledResultStep bg={location.bgImageBlack}>
       {result && displayedOtto && (
         <Head>
           <title>

--- a/src/components/AdventurePopup/ResultStep/index.tsx
+++ b/src/components/AdventurePopup/ResultStep/index.tsx
@@ -175,19 +175,17 @@ export default function ResultStep() {
   }
 
   const exploreAgainButton = otto?.adventureStatus !== AdventureOttoStatus.Resting && (
-    <Button
-      Typography={Headline}
-      onClick={() => {
-        closePopup();
-        openPopup(
-          undefined,
-          AdventurePopupStep.Map
-        );
-      }}
-    >
-      {t('explore_again_btn')}
-    </Button>
-  );
+  <Button
+    Typography={Headline}
+    onClick={() => {
+      setOtto(otto, true);
+      closePopup();
+      openPopup(undefined, AdventurePopupStep.Map);
+    }}
+  >
+    {t('explore_again_btn')}
+  </Button>
+);
 
   return (
     <StyledResultStep bg={location.bgImageBlack}>


### PR DESCRIPTION
This will skip the location step and go straight to the preview step, saving the user another 2 clicks.