### PR TITLE
Hook up account disconnect button to deactivate wallet connection

### DIFF
--- a/src/components/SideMenu/Account.tsx
+++ b/src/components/SideMenu/Account.tsx
@@ -36,11 +36,11 @@ const StyledInfo = styled.div`
 `
 
 const StyledDisconnectButtoon = styled(Caption).attrs({ as: 'button' })`
-  color: ${({ theme }) => theme.colors.darkGray100};
+  color: ${({ theme }) => theme.colors.darkGray400};
 `
 
 export default function Account() {
-  const { account } = useEthers()
+  const { account, deactivate } = useEthers()
   const { t } = useTranslation('', { keyPrefix: 'side_menu' })
 
   const address = `${account!.slice(0, 3)}...${account!.slice(account!.length - 3, account!.length)}`
@@ -51,7 +51,7 @@ export default function Account() {
         <ContentExtraSmall>{address}</ContentExtraSmall>
         <ContentExtraSmall>Polygon</ContentExtraSmall>
       </StyledInfo>
-      <StyledDisconnectButtoon>{t('disconnect')}</StyledDisconnectButtoon>
+      <StyledDisconnectButtoon onClick={() => deactivate()}>{t('disconnect')}</StyledDisconnectButtoon>
     </StyledContainer>
   )
 }

--- a/src/components/SideMenu/Account.tsx
+++ b/src/components/SideMenu/Account.tsx
@@ -35,7 +35,7 @@ const StyledInfo = styled.div`
   flex-direction: column;
 `
 
-const StyledDisconnectButtoon = styled(Caption).attrs({ as: 'button' })`
+const StyledDisconnectButton = styled(Caption).attrs({ as: 'button' })`
   color: ${({ theme }) => theme.colors.darkGray400};
 `
 
@@ -51,7 +51,7 @@ export default function Account() {
         <ContentExtraSmall>{address}</ContentExtraSmall>
         <ContentExtraSmall>Polygon</ContentExtraSmall>
       </StyledInfo>
-      <StyledDisconnectButtoon onClick={() => deactivate()}>{t('disconnect')}</StyledDisconnectButtoon>
+      <StyledDisconnectButton onClick={() => deactivate()}>{t('disconnect')}</StyledDisconnectButton>
     </StyledContainer>
   )
 }


### PR DESCRIPTION
#Description

The `Disconnect` button in the account information doesn't function when clicked and appears disabled.
![image](https://user-images.githubusercontent.com/99622829/224188565-0edf581d-feaa-4327-908d-f9d02de6661c.png)

#Notes

- Hooked up the `deactivate()` function to disconnect the wallet connect when the `Disconnect` button is clicked.
- Fixed the spelling error in `<StyledDisconnectButton>` 
- Change the style of the `Disconnect` button so it appear enabled.

#Testing

Connect wallet
Click upper right hamburger menu
Click `Disconnect`
Verify wallet is not longer connected to the app by navigating to main page and `Connect` button is active.


