### PR TITLE
Bulk Equip Menu Tweaks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,5 +4,4 @@
 yarn check-types
 yarn next lint --quiet
 ./node_modules/.bin/lint-staged
-node scripts/imagemin.mjs {src,public}/**/*.{jpg,png,svg,gif}
 

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -130,10 +130,6 @@ const StyledAmount = styled.div`
   background-color: rgba(255, 255, 255, 0.5);
 `
 
-const StyledAmountText = styled(ContentLarge)`
-  opacity: 1;
-`
-
 const StyledEquipped = styled.div`
   position: absolute;
   z-index: 1;
@@ -230,7 +226,7 @@ export default memo(function ItemCell({
       </StyledRarity>
       {amount > 1 && !hideAmount && (
         <StyledAmount>
-          <StyledAmountText>{amount}</StyledAmountText>
+          <ContentLarge>{amount}</ContentLarge>
         </StyledAmount>
       )}
       {equippedByOtto && (

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -117,17 +117,21 @@ const StyledRarity = styled.div<{ rarity?: string }>`
 
 const StyledAmount = styled.div`
   z-index: 1;
-  width: 40px;
-  height: 40px;
+  width: 30px;
+  height: 30px;
   position: absolute;
-  bottom: 0;
-  right: 0;
+  bottom: 5px;
+  right: 5px;
   border: 2px solid ${({ theme }) => theme.colors.otterBlack};
   border-radius: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: rgba(255, 255, 255, 0.5);
+`
+
+const StyledAmountText = styled(ContentLarge)`
+  opacity: 1;
 `
 
 const StyledEquipped = styled.div`
@@ -226,7 +230,7 @@ export default memo(function ItemCell({
       </StyledRarity>
       {amount > 1 && !hideAmount && (
         <StyledAmount>
-          <ContentLarge>{amount}</ContentLarge>
+          <StyledAmountText>{amount}</StyledAmountText>
         </StyledAmount>
       )}
       {equippedByOtto && (

--- a/src/components/OttoItemsPopup/ItemList.tsx
+++ b/src/components/OttoItemsPopup/ItemList.tsx
@@ -57,7 +57,6 @@ export default function ItemList({ otto, selectItem, selectedItemId }: ItemListP
       {restItems.map(item => (
         <StyledItem
           key={item.id}
-          hideAmount
           unavailable={!otto?.canWear(item)}
           item={item}
           currentOtto={otto}

--- a/src/components/OttoItemsPopup/ItemPreview.tsx
+++ b/src/components/OttoItemsPopup/ItemPreview.tsx
@@ -132,7 +132,7 @@ export default memo(function ItemPreview({
   const { equipItem, removeItem } = useOtto()
   const { draftOtto: otto } = useAdventureOtto()
   const { t } = useTranslation('', { keyPrefix: 'ottoItemsPopup' })
-  const { t : tMyItems } = useTranslation('', { keyPrefix: 'my_items' })
+  const { t: tMyItems } = useTranslation('', { keyPrefix: 'my_items' })
   const containerRef = useRef<HTMLDivElement | null>(null)
   const equippedItem = otto?.equippedItems.find(item => item.metadata.type === traitType)
   const equippedOtto = useMyOtto(selectedItem?.equippedBy)
@@ -172,14 +172,15 @@ export default memo(function ItemPreview({
               )}
               {metadata?.name}
             </StyledItemName>
-            {metadata && <StyledRarityScore>
-              {tMyItems('total_rarity_score', {
-                total: metadata.totalRarityScore,
-                brs: metadata.baseRarityScore,
-                rrs: metadata.relativeRarityScore,
-              })}
-            </StyledRarityScore>
-            }
+            {metadata && (
+              <StyledRarityScore>
+                {tMyItems('total_rarity_score', {
+                  total: metadata.totalRarityScore,
+                  brs: metadata.baseRarityScore,
+                  rrs: metadata.relativeRarityScore,
+                })}
+              </StyledRarityScore>
+            )}
             {metadata && <TraitLabels highlightMatched metadata={metadata} />}
             <StyledWearCount>{t('equippedCount', { count: metadata?.equippedCount ?? 0 })}</StyledWearCount>
             <StyledItemLevels>

--- a/src/components/OttoItemsPopup/ItemPreview.tsx
+++ b/src/components/OttoItemsPopup/ItemPreview.tsx
@@ -62,6 +62,8 @@ const StyledItemImage = styled.div`
   flex: 0;
 `
 
+const StyledRarityScore = styled(Note).attrs({ as: 'p' })``
+
 const StyledItemAttrs = styled.div`
   flex: 1;
   display: flex;
@@ -130,6 +132,7 @@ export default memo(function ItemPreview({
   const { equipItem, removeItem } = useOtto()
   const { draftOtto: otto } = useAdventureOtto()
   const { t } = useTranslation('', { keyPrefix: 'ottoItemsPopup' })
+  const { t : tMyItems } = useTranslation('', { keyPrefix: 'my_items' })
   const containerRef = useRef<HTMLDivElement | null>(null)
   const equippedItem = otto?.equippedItems.find(item => item.metadata.type === traitType)
   const equippedOtto = useMyOtto(selectedItem?.equippedBy)
@@ -169,6 +172,14 @@ export default memo(function ItemPreview({
               )}
               {metadata?.name}
             </StyledItemName>
+            {metadata && <StyledRarityScore>
+              {tMyItems('total_rarity_score', {
+                total: metadata.totalRarityScore,
+                brs: metadata.baseRarityScore,
+                rrs: metadata.relativeRarityScore,
+              })}
+            </StyledRarityScore>
+            }
             {metadata && <TraitLabels highlightMatched metadata={metadata} />}
             <StyledWearCount>{t('equippedCount', { count: metadata?.equippedCount ?? 0 })}</StyledWearCount>
             <StyledItemLevels>

--- a/src/components/OttoItemsPopup/index.tsx
+++ b/src/components/OttoItemsPopup/index.tsx
@@ -187,11 +187,9 @@ export default memo(function OttoItemsPopup({ className, maxWidth, height, onReq
           <PreviewAttrs otto={otto} actions={actions} />
           <StyledActions>
             <StyledAction>
-              <StyledActionLabel>{t('sort')}</StyledActionLabel>
               <SortedBySelector />
             </StyledAction>
             <StyledAction>
-              <StyledActionLabel>{t('filter')}</StyledActionLabel>
               <FilterSelector />
             </StyledAction>
           </StyledActions>


### PR DESCRIPTION
1. Make sort and filter consistent with changes in my-items. (For now, still omits search bar and ascending, as before)
2. Modify styling of the amount display on items to add transparency and shift location slightly
3. Show the amount display in the bulk equip modals
4. Remove imagemin from being directly invoked by pre-commit as it should be covered in lint-staged.

Note: imagemin doesn't work on my local setup either, may need a separate tweak or explanation on what environment it works for.