### PR TITLE
Use createPortal to pop out otto tooltip

### DIFF
--- a/src/components/Help/index.tsx
+++ b/src/components/Help/index.tsx
@@ -27,6 +27,22 @@ const StyledContent = styled.div`
   display: inline-block;
 `
 
+const tooltipOverridePosition = (
+  { left, top }: { left: number; top: number },
+  _currentEvent: Event,
+  _currentTarget: EventTarget,
+  node: HTMLSpanElement | HTMLDivElement | null
+) => {
+  if (node) {
+    const d = document.documentElement
+    left = Math.min(d.clientWidth - node.clientWidth, left)
+    top = Math.min(d.clientHeight - node.clientHeight, top)
+    left = Math.max(0, left)
+    top = Math.max(0, top)
+  }
+  return { top, left }
+}
+
 export interface HelpProps {
   message: string
   className?: string
@@ -56,7 +72,7 @@ export default function Help({
         {!noicon && <StyledIcon src={icon} />}
       </StyledContent>
       {mounted && (
-        <ReactTooltip id={id} effect="solid">
+        <ReactTooltip id={id} overridePosition={tooltipOverridePosition} effect="solid">
           <StyledNote>{message}</StyledNote>
         </ReactTooltip>
       )}

--- a/src/components/Help/index.tsx
+++ b/src/components/Help/index.tsx
@@ -27,6 +27,14 @@ const StyledContent = styled.div`
   display: inline-block;
 `
 
+const StyledReactTooltip = styled(ReactTooltip)`
+  &.place-top {
+    &:after {
+      visibility: hidden;
+    }
+  }
+`
+
 const tooltipOverridePosition = (
   { left, top }: { left: number; top: number },
   _currentEvent: Event,
@@ -72,9 +80,9 @@ export default function Help({
         {!noicon && <StyledIcon src={icon} />}
       </StyledContent>
       {mounted && (
-        <ReactTooltip id={id} overridePosition={tooltipOverridePosition} effect="solid">
+        <StyledReactTooltip id={id} overridePosition={tooltipOverridePosition} effect="solid">
           <StyledNote>{message}</StyledNote>
-        </ReactTooltip>
+        </StyledReactTooltip>
       )}
     </StyledContainer>
   )

--- a/src/components/Help/index.tsx
+++ b/src/components/Help/index.tsx
@@ -49,12 +49,10 @@ export default function Help({
   noicon,
 }: PropsWithChildren<HelpProps>) {
   const [id] = useState(() => `help-${nextId++}`)
-  const [mounted, setMounted] = useState(false)
   const [modalRoot, setModalRoot] = useState<Element | null>(null)
 
   // solve an ssr issue
   useEffect(() => {
-    setMounted(true)
     setModalRoot(document.querySelector('#modal-root'))
   }, [])
 
@@ -64,13 +62,12 @@ export default function Help({
         {children}
         {!noicon && <StyledIcon src={icon} />}
       </StyledContent>
-      {mounted &&
-        ReactDOM.createPortal(
-          <StyledReactTooltip id={id} effect="solid">
-            <StyledNote>{message}</StyledNote>
-          </StyledReactTooltip>,
-          modalRoot ?? document.body
-        )}
+      {ReactDOM.createPortal(
+        <StyledReactTooltip id={id} effect="solid">
+          <StyledNote>{message}</StyledNote>
+        </StyledReactTooltip>,
+        modalRoot ?? document.body
+      )}
     </StyledContainer>
   )
 }

--- a/src/components/Help/index.tsx
+++ b/src/components/Help/index.tsx
@@ -49,12 +49,6 @@ export default function Help({
   noicon,
 }: PropsWithChildren<HelpProps>) {
   const [id] = useState(() => `help-${nextId++}`)
-  const [modalRoot, setModalRoot] = useState<Element | null>(null)
-
-  // solve an ssr issue
-  useEffect(() => {
-    setModalRoot(document.querySelector('#modal-root'))
-  }, [])
 
   return (
     <StyledContainer>
@@ -66,7 +60,7 @@ export default function Help({
         <StyledReactTooltip id={id} effect="solid">
           <StyledNote>{message}</StyledNote>
         </StyledReactTooltip>,
-        modalRoot ?? document.body
+        document.querySelector('#modal-root') ?? document.body
       )}
     </StyledContainer>
   )

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -27,7 +27,6 @@ const StyledItemCell = styled.button<{
   border-radius: 5px;
   position: relative;
   background: ${({ theme, rarity }) => (rarity ? (theme.colors.rarity as any)[rarity] : theme.colors.lightGray200)};
-  z-index: 0;
 
   &::before {
     content: '';
@@ -54,7 +53,6 @@ const StyledItemCell = styled.button<{
 
 const StyledSelectedFrame = styled.div<{ right?: boolean }>`
   position: absolute;
-  z-index: 1;
   left: 0;
   top: 0;
   width: 100%;
@@ -103,7 +101,6 @@ const StyledImageContainer = styled.div`
 
 const StyledRarity = styled.div<{ rarity?: string }>`
   position: absolute;
-  z-index: 1;
   top: 3px;
   right: 3px;
   padding-left: 3px;
@@ -165,7 +162,7 @@ const StyledUnreturnable = styled.div`
   }
 `
 
-const StyledOttoLink = styled.a`
+const StyledOttoThumb = styled.div`
   display: block;
   width: 24px;
 `
@@ -234,11 +231,9 @@ export default memo(function ItemCell({
       {equippedByOtto && (
         <StyledEquipped>
           <Help noicon message={equippedByOtto.name}>
-            <Link href={`/my-ottos/${equippedByOtto.id}`} passHref>
-              <StyledOttoLink onClick={e => e.stopPropagation()}>
-                <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
-              </StyledOttoLink>
-            </Link>
+            <StyledOttoThumb onClick={e => e.stopPropagation()}>
+              <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
+            </StyledOttoThumb>
           </Help>
         </StyledEquipped>
       )}

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -162,7 +162,7 @@ const StyledUnreturnable = styled.div`
   }
 `
 
-const StyledOttoThumb = styled.div`
+const StyledOttoLink = styled.a`
   display: block;
   width: 24px;
 `
@@ -231,9 +231,18 @@ export default memo(function ItemCell({
       {equippedByOtto && (
         <StyledEquipped>
           <Help noicon message={equippedByOtto.name}>
-            <StyledOttoThumb onClick={e => e.stopPropagation()}>
-              <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
-            </StyledOttoThumb>
+            {!currentOtto && (
+              <Link href={`/my-ottos/${equippedByOtto.id}`} passHref>
+                <StyledOttoLink onClick={e => e.stopPropagation()}>
+                  <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
+                </StyledOttoLink>
+              </Link>
+            )}
+            {currentOtto && (
+              <StyledOttoLink onClick={e => e.stopPropagation()}>
+                <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
+              </StyledOttoLink>
+            )}
           </Help>
         </StyledEquipped>
       )}

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -27,6 +27,7 @@ const StyledItemCell = styled.button<{
   border-radius: 5px;
   position: relative;
   background: ${({ theme, rarity }) => (rarity ? (theme.colors.rarity as any)[rarity] : theme.colors.lightGray200)};
+  z-index: 0;
 
   &::before {
     content: '';
@@ -53,6 +54,7 @@ const StyledItemCell = styled.button<{
 
 const StyledSelectedFrame = styled.div<{ right?: boolean }>`
   position: absolute;
+  z-index: 1;
   left: 0;
   top: 0;
   width: 100%;
@@ -101,6 +103,7 @@ const StyledImageContainer = styled.div`
 
 const StyledRarity = styled.div<{ rarity?: string }>`
   position: absolute;
+  z-index: 1;
   top: 3px;
   right: 3px;
   padding-left: 3px;

--- a/src/components/ItemCell/index.tsx
+++ b/src/components/ItemCell/index.tsx
@@ -239,7 +239,7 @@ export default memo(function ItemCell({
               </Link>
             )}
             {currentOtto && (
-              <StyledOttoLink onClick={e => e.stopPropagation()}>
+              <StyledOttoLink as="span">
                 <Image src={equippedByOtto.image} layout="responsive" width={24} height={24} />
               </StyledOttoLink>
             )}


### PR DESCRIPTION
This looks better now and more like the original. Reverted z-index changes from the previous change, and only thing missing was z-index styling to pop out the tooltip above everything else.