### PR TITLE
Disconnect invokes close on coinbase/walletconnect

### DIFF
--- a/src/components/SideMenu/Account.tsx
+++ b/src/components/SideMenu/Account.tsx
@@ -1,3 +1,5 @@
+import { Web3Provider } from '@ethersproject/providers'
+import WalletConnectProvider from '@walletconnect/ethereum-provider'
 import { useEthers } from '@usedapp/core'
 import { useTranslation } from 'next-i18next'
 import styled from 'styled-components'
@@ -40,8 +42,18 @@ const StyledDisconnectButton = styled(Caption).attrs({ as: 'button' })`
 `
 
 export default function Account() {
-  const { account, deactivate } = useEthers()
+  const { account, deactivate, library } = useEthers()
   const { t } = useTranslation('', { keyPrefix: 'side_menu' })
+  const doDisconnect = () => {
+    deactivate()
+    if (library instanceof Web3Provider) {
+      if (library.provider instanceof WalletConnectProvider) {
+        library.provider.disconnect()
+      } else if (typeof (library.provider as any).close === 'function') {
+        ;(library.provider as any).close()
+      }
+    }
+  }
 
   const address = account ? `${account.slice(0, 3)}...${account.slice(account.length - 3, account.length)}` : ''
 
@@ -51,7 +63,7 @@ export default function Account() {
         <ContentExtraSmall>{address}</ContentExtraSmall>
         <ContentExtraSmall>Polygon</ContentExtraSmall>
       </StyledInfo>
-      <StyledDisconnectButton onClick={() => deactivate()}>{t('disconnect')}</StyledDisconnectButton>
+      <StyledDisconnectButton onClick={() => doDisconnect()}>{t('disconnect')}</StyledDisconnectButton>
     </StyledContainer>
   )
 }

--- a/src/components/WalletSelector/index.tsx
+++ b/src/components/WalletSelector/index.tsx
@@ -1,5 +1,5 @@
 import { useEthers } from '@usedapp/core'
-import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
+import WalletConnectProvider from '@walletconnect/ethereum-provider'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import { useTranslation } from 'next-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -18,11 +18,11 @@ const CoinbaseWallet = new WalletLinkConnector({
   supportedChainIds: [137],
 })
 
-export const walletConnectConnector = new WalletConnectConnector({
+const walletConnectProvider = new WalletConnectProvider({
   rpc: {
     137: 'https://polygon-rpc.com',
   },
-  qrcode: true,
+  chainId: 137,
 })
 
 const StyledContainer = styled.div`
@@ -63,6 +63,10 @@ const WalletSelector = (): JSX.Element => {
   const dispatch = useDispatch()
   const { account, activateBrowserWallet, activate } = useEthers()
   const connectingWallet = useSelector(selectConnectingWallet)
+  const activateWalletConnect = async () => {
+    await walletConnectProvider.enable()
+    activate(walletConnectProvider)
+  }
   return (
     <Popup
       show={connectingWallet && !account}
@@ -75,7 +79,7 @@ const WalletSelector = (): JSX.Element => {
           <Name>Metamask</Name>
           <Icon src={metamask.src} alt="Metamask logo" />
         </Option>
-        <Option onClick={() => activate(walletConnectConnector)}>
+        <Option onClick={activateWalletConnect}>
           <Name>WalletConnect</Name>
           <Icon src={walletConnect.src} alt="WalletConnect logo" />
         </Option>


### PR DESCRIPTION
Actually allows clean disconnect so that on refresh connecting will ask for connection again (rather than remember the address and requiring you to clear site data to redo)