### PR TITLE
Add staking information and timers

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -937,7 +937,8 @@
     "ongoing": "Ongoing",
     "resting": "Resting",
     "ready": "Ready",
-    "unavailable": "Unavailable"
+    "unavailable": "Unavailable",
+    "staking": "Staking"
   },
   "adventurePopup": {
     "start": "Let's Go!",
@@ -1020,6 +1021,7 @@
     "ready": "{{name}} is ready for an adventure!",
     "ongoing": "{{name}} is exploring {{location}}...",
     "finished": "{{name}} has finished exploring {{location}}!",
+    "staking": "{{name}} is relaxing at {{location}}",
     "results": "Results"
   },
   "adventureLocationPopup": {

--- a/public/locales/zh-cn/common.json
+++ b/public/locales/zh-cn/common.json
@@ -936,9 +936,9 @@
       "used": "使用 {{ amount }}",
       "title_stake": "{{name}} 正在放松中...",
       "elapsed_time": "已过去时间：{{time}}",
-      "rounds": "Rounds: {{rounds}}",
+      "rounds": "第几轮: {{rounds}}",
       "max": "最大值",
-      "next_round_in": "Next round in: {{time}}"
+      "next_round_in": "下一轮倒数: {{time}}"
     },
     "resultStep": {
       "journal": "冒险日志",

--- a/public/locales/zh-cn/common.json
+++ b/public/locales/zh-cn/common.json
@@ -914,7 +914,8 @@
     "ongoing": "冒险中",
     "resting": "休息中",
     "ready": "闲置中",
-    "unavailable": "无法冒险"
+    "unavailable": "无法冒险",
+    "staking": "Staking"
   },
   "adventurePopup": {
     "start": "出发 GO!",
@@ -997,6 +998,7 @@
     "ready": "{{name}} 已经准备好冒险！",
     "ongoing": "{{name}} 正在 {{location}} 冒险中...",
     "finished": "{{name}} 完成了对 {{location}} 的探索！",
+    "staking": "{{name}} is relaxing at {{location}}",
     "results":"成果"
   },
   "adventureLocationPopup": {

--- a/public/locales/zh-cn/common.json
+++ b/public/locales/zh-cn/common.json
@@ -915,7 +915,7 @@
     "resting": "休息中",
     "ready": "闲置中",
     "unavailable": "无法冒险",
-    "staking": "Staking"
+    "staking": "长时间冒险中"
   },
   "adventurePopup": {
     "start": "出发 GO!",
@@ -935,7 +935,7 @@
       "buy_now": "马上购买 >",
       "used": "使用 {{ amount }}",
       "title_stake": "{{name}} 正在放松中...",
-      "elapsed_time": "Elapsed Time: {{time}}",
+      "elapsed_time": "已过去时间：{{time}}",
       "rounds": "Rounds: {{rounds}}",
       "max": "最大值",
       "next_round_in": "Next round in: {{time}}"
@@ -998,7 +998,7 @@
     "ready": "{{name}} 已经准备好冒险！",
     "ongoing": "{{name}} 正在 {{location}} 冒险中...",
     "finished": "{{name}} 完成了对 {{location}} 的探索！",
-    "staking": "{{name}} is relaxing at {{location}}",
+    "staking": "{{name}} 正在 {{location}} 休息",
     "results":"成果"
   },
   "adventureLocationPopup": {

--- a/public/locales/zh-cn/common.json
+++ b/public/locales/zh-cn/common.json
@@ -433,8 +433,8 @@
     "zodiac_sign": "星座： {{constellation}}",
     "total_rarity_score": "稀有度总计： {{score}} (BRS {{brs}} + RRS {{rrs}})",
     "theme_boost": "主题加成",
-    "attribute_points": "Available Attribute Points: {{attributePoints}}",
-    "attribute_points_button": "Add Now >"
+    "attribute_points": "可用点数: {{attributePoints}}",
+    "attribute_points_button": "立马分配 >"
   },
   "otto_one": "{{count}} 只阿獭",
   "otto_other": "{{count}} 只阿獭",

--- a/public/locales/zh-tw/common.json
+++ b/public/locales/zh-tw/common.json
@@ -915,7 +915,7 @@
     "resting": "休息中",
     "ready": "閒置中",
     "unavailable": "無法冒險",
-    "staking": "Staking"
+    "staking": "長時間冒險中"
   },
   "adventurePopup": {
     "start": "出發 GO!",
@@ -935,10 +935,10 @@
       "buy_now": "馬上購買 >",
       "used": "使用 {{ amount }}",
       "title_stake": "{{name}} 正在放鬆中...",
-      "elapsed_time": "Elapsed Time: {{time}}",
-      "rounds": "Rounds: {{rounds}}",
+      "elapsed_time": "已過去時間：{{time}}",
+      "rounds": "第幾輪：{{rounds}}",
       "max": "最大值",
-      "next_round_in": "Next round in: {{time}}"
+      "next_round_in": "下一輪倒數：{{time}}"
     },
     "resultStep": {
       "journal": "冒險日誌",
@@ -998,7 +998,7 @@
     "ready": "{{name}} 已經準備好冒險！",
     "ongoing": "{{name}} 正在 {{location}} 冒險中...",
     "finished": "{{name}} 完成了對 {{location}} 的探索！",
-    "staking": "{{name}} is relaxing at {{location}}",
+    "staking": "{{name}} 正在 {{location}} 休息",
     "results":"成果"
   },
   "adventureLocationPopup": {

--- a/public/locales/zh-tw/common.json
+++ b/public/locales/zh-tw/common.json
@@ -914,7 +914,8 @@
     "ongoing": "冒險中",
     "resting": "休息中",
     "ready": "閒置中",
-    "unavailable": "無法冒險"
+    "unavailable": "無法冒險",
+    "staking": "Staking"
   },
   "adventurePopup": {
     "start": "出發 GO!",
@@ -997,6 +998,7 @@
     "ready": "{{name}} 已經準備好冒險！",
     "ongoing": "{{name}} 正在 {{location}} 冒險中...",
     "finished": "{{name}} 完成了對 {{location}} 的探索！",
+    "staking": "{{name}} is relaxing at {{location}}",
     "results":"成果"
   },
   "adventureLocationPopup": {

--- a/src/components/AdventureOttoCard/index.tsx
+++ b/src/components/AdventureOttoCard/index.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image'
 import { memo } from 'react'
 import styled from 'styled-components/macro'
 import { Caption, ContentExtraSmall, ContentSmall, ContentMedium, Note } from 'styles/typography'
+import { computeStakingInfo } from 'utils/adventure'
 import RemainingTime from './RemainingTime'
 
 interface AdventureOttoCardProps {
@@ -173,6 +174,8 @@ export default memo(function AdventureOttoCard({ bg, adventureStatus, otto }: Ad
   const { setOtto } = useOtto()
   const openPopup = useOpenAdventurePopup()
   const goToAdventureResultStep = useGoToAdventureResultStep()
+  const now = new Date()
+  const { nextRoundTime } = computeStakingInfo(now, otto, location)
 
   const check = () => {
     if (location) {
@@ -213,6 +216,7 @@ export default memo(function AdventureOttoCard({ bg, adventureStatus, otto }: Ad
         }
         break
       case AdventureOttoStatus.Ongoing:
+      case AdventureOttoStatus.Staking:
         if (otto.latestAdventurePass?.canFinishAt !== undefined) {
           check()
         }
@@ -227,6 +231,7 @@ export default memo(function AdventureOttoCard({ bg, adventureStatus, otto }: Ad
     [AdventureOttoStatus.Ongoing]: t('ongoing', { name: otto.name, location: location?.name }),
     [AdventureOttoStatus.Ready]: t('ready', { name: otto.name }),
     [AdventureOttoStatus.Resting]: t('resting_1', { name: otto.name }),
+    [AdventureOttoStatus.Staking]: t('staking', { name: otto.name, location: location?.name }),
   }
 
   const showJournalButton =
@@ -290,13 +295,16 @@ export default memo(function AdventureOttoCard({ bg, adventureStatus, otto }: Ad
                 </Button>
               )}
               {(otto.adventureStatus === AdventureOttoStatus.Resting ||
-                (otto.adventureStatus === AdventureOttoStatus.Ongoing &&
+                ((otto.adventureStatus === AdventureOttoStatus.Ongoing ||
+                  otto.adventureStatus === AdventureOttoStatus.Staking) &&
                   otto.latestAdventurePass?.canFinishAt !== undefined)) && (
                 <a onClick={onClick}>
                   <StyledRemainingTime
                     target={
                       otto.adventureStatus === AdventureOttoStatus.Resting
                         ? otto.restingUntil ?? new Date()
+                        : otto.adventureStatus === AdventureOttoStatus.Staking && nextRoundTime
+                        ? nextRoundTime
                         : otto.latestAdventurePass?.canFinishAt ?? new Date()
                     }
                   />

--- a/src/components/AdventurePopup/ResultStep/JournalSection.tsx
+++ b/src/components/AdventurePopup/ResultStep/JournalSection.tsx
@@ -34,8 +34,8 @@ export default function AdventureJournal({ className, result }: Props) {
 
       <StyledResultContainer>
         <StyledResultLabel>{t('result_label')}</StyledResultLabel>
-        <StyledResultValue succeeded={result?.success}>
-          {result && t(result.success ? 'result_succeeded' : 'result_failed')}
+        <StyledResultValue succeeded={result?.success && result?.rewards.exp > 0}>
+          {result && t(result.success && result.rewards.exp > 0 ? 'result_succeeded' : 'result_failed')}
           {!result && <Skeleton />}
         </StyledResultValue>
       </StyledResultContainer>

--- a/src/models/Otto.ts
+++ b/src/models/Otto.ts
@@ -8,6 +8,8 @@ import { AdventurePass, fromRawPass } from './AdventurePass'
 import { AdventureResult } from './AdventureResult'
 import { ItemMetadata, Item } from './Item'
 
+const STAKING_LOCATIONS = [10]
+
 export enum TraitCollection {
   Genesis = 'genesis',
   Second = 'second',
@@ -93,6 +95,7 @@ export interface Stat {
 export enum AdventureOttoStatus {
   Finished = 'finished',
   Ongoing = 'ongoing',
+  Staking = 'staking',
   Resting = 'resting',
   Ready = 'ready',
   Unavailable = 'unavailable',
@@ -308,6 +311,9 @@ export default class Otto {
       }
     }
     if (this.latestAdventurePass && !this.latestAdventurePass.finishedAt) {
+      if (STAKING_LOCATIONS.findIndex(x => x === this.latestAdventurePass?.locationId) !== -1) {
+        return AdventureOttoStatus.Staking
+      }
       if (this.latestAdventurePass.canFinishAt > now) {
         return AdventureOttoStatus.Ongoing
       }

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -50,6 +50,7 @@ export const colors = {
     [AdventureOttoStatus.Resting]: '#FFC978',
     [AdventureOttoStatus.Ongoing]: '#B3A4FF',
     [AdventureOttoStatus.Unavailable]: '#99B6FF',
+    [AdventureOttoStatus.Staking]: '#A6B5FF',
   },
   treasury: {
     clamLpRed: ['rgba(238,75,78,1)', 'rgba(219, 55, 55, 0.5)'],


### PR DESCRIPTION
- Adds staking tab
- Shows Staking vs Ongoing/finished and has a timer for the current round
- Shows round information also during the first round, before it did not show
- Shows "failure" if all rounds failed.
- @Appppo needs localization:
  - "Staking" tab translation
  - "{{name}} is relaxing at {{location}}"
  - will resolve later 

<img width="540" alt="Screenshot 2023-09-07 at 3 46 36 PM" src="https://github.com/OtterClam/otto-app/assets/34953718/0bd9eebb-f386-45dd-9a9b-07b78f953512">
